### PR TITLE
avcodec/ccaption_dec: Corrected SCC decoding of Single Quotation Mark

### DIFF
--- a/libavcodec/ccaption_dec.c
+++ b/libavcodec/ccaption_dec.c
@@ -107,10 +107,10 @@ enum cc_charset {
         ENTRY(0x23, "\u00da")                            \
         ENTRY(0x24, "\u00dc")                            \
         ENTRY(0x25, "\u00fc")                            \
-        ENTRY(0x26, "\u00b4")                            \
+        ENTRY(0x26, "\u2018")                            \
         ENTRY(0x27, "\u00a1")                            \
         ENTRY(0x28, "*")                                 \
-        ENTRY(0x29, "\u2018")                            \
+        ENTRY(0x29, "'")                                 \
         ENTRY(0x2a, "-")                                 \
         ENTRY(0x2b, "\u00a9")                            \
         ENTRY(0x2c, "\u2120")                            \


### PR DESCRIPTION
Corrected the EIA-608 OPENING SINGLE QUOTE (0x26) to decode as Unicode LEFT SINGLE QUOTATION MARK (U+2018), rather than Unicode ACUTE ACCENT (U+00b4). Ref: CTA-608-E, Table 5, Note 3.

Corrected the EIA-608 PLAIN SINGLE QUOTE (0x29) to decode as Unicode APOSTROPHE (U+0027), rather than Unicode LEFT SINGLE QUOTATION MARK (U+2018). Ref: CTA-608-E, Table 6, Note 5.

The correct behavior is highlighted in CTA-608-E, available for $0 from https://shop.cta.tech/products/cta-608 (registration required).